### PR TITLE
feat: Improve refs garbage collection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
@@ -131,6 +132,10 @@ type Redis struct {
 	// URL used to connect onto the redis endpoint
 	// format: redis[s]://[:password@]host[:port][/db-number][?option=value])
 	URL string `yaml:"url"`
+
+	ProjectTTL time.Duration `default:"168h" yaml:"project_ttl"`
+	RefTTL     time.Duration `default:"1h" yaml:"ref_ttl"`
+	MetricTTL  time.Duration `default:"1h" yaml:"metric_ttl"`
 }
 
 // Pull ..

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,10 @@ func TestNew(t *testing.T) {
 	c.ProjectDefaults.Pull.Pipeline.Jobs.RunnerDescription.Enabled = true
 	c.ProjectDefaults.Pull.Pipeline.Jobs.RunnerDescription.AggregationRegexp = `shared-runners-manager-(\d*)\.gitlab\.com`
 	c.ProjectDefaults.Pull.Pipeline.Variables.Regexp = `.*`
+
+	c.Redis.ProjectTTL = 168 * time.Hour
+	c.Redis.RefTTL = 1 * time.Hour
+	c.Redis.MetricTTL = 1 * time.Hour
 
 	assert.Equal(t, c, New())
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,14 +48,23 @@ func New(ctx context.Context, cfg config.Config, version string) (c Controller, 
 		return
 	}
 
-	if err = c.configureRedis(ctx, cfg.Redis.URL); err != nil {
+	if err = c.configureRedis(ctx, &cfg.Redis); err != nil {
 		return
 	}
 
 	c.TaskController = NewTaskController(ctx, c.Redis, cfg.Gitlab.MaximumJobsQueueSize)
 	c.registerTasks()
 
-	c.Store = store.New(ctx, c.Redis, c.Config.Projects)
+	var redisStore *store.Redis
+	if c.Redis != nil {
+		redisStore = store.NewRedisStore(c.Redis, store.WithTTLConfig(&store.RedisTTLConfig{
+			Project: cfg.Redis.ProjectTTL,
+			Ref:     cfg.Redis.RefTTL,
+			Metric:  cfg.Redis.MetricTTL,
+		}))
+	}
+
+	c.Store = store.New(ctx, redisStore, c.Config.Projects)
 
 	if err = c.configureGitlab(cfg.Gitlab, version); err != nil {
 		return
@@ -170,11 +179,11 @@ func (c *Controller) configureGitlab(cfg config.Gitlab, version string) (err err
 	return
 }
 
-func (c *Controller) configureRedis(ctx context.Context, url string) (err error) {
+func (c *Controller) configureRedis(ctx context.Context, config *config.Redis) (err error) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "controller:configureRedis")
 	defer span.End()
 
-	if len(url) <= 0 {
+	if len(config.URL) <= 0 {
 		log.Debug("redis url is not configured, skipping configuration & using local driver")
 
 		return
@@ -184,7 +193,7 @@ func (c *Controller) configureRedis(ctx context.Context, url string) (err error)
 
 	var opt *redis.Options
 
-	if opt, err = redis.ParseURL(url); err != nil {
+	if opt, err = redis.ParseURL(config.URL); err != nil {
 		return
 	}
 

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -169,7 +169,9 @@ func (c *Controller) GarbageCollectRefs(ctx context.Context) error {
 	}
 
 	storedRefsLen := len(storedRefs)
-	for i, ref := range storedRefs {
+	var i int
+	for _, ref := range storedRefs {
+		i++
 		log.WithFields(log.Fields{"progress": i, "total": storedRefsLen}).Debug("ongoing 'refs' garbage collection")
 		if c.Store.HasRefExpired(ctx, ref.Key()) {
 			if err = deleteRef(ctx, c.Store, ref, "expired"); err != nil {
@@ -287,8 +289,10 @@ func (c *Controller) GarbageCollectMetrics(ctx context.Context) error {
 	}
 
 	storedMetricsLen := len(storedMetrics)
+	var i int
 	for k, m := range storedMetrics {
-		log.WithFields(log.Fields{"progress": k, "total": storedMetricsLen}).Debug("ongoing 'metrics' garbage collection")
+		i++
+		log.WithFields(log.Fields{"progress": i, "total": storedMetricsLen}).Debug("ongoing 'metrics' garbage collection")
 		if c.Store.HasMetricExpired(ctx, m.Key()) {
 			if err = deleteMetric(ctx, c.Store, m, "expired"); err != nil {
 				return err

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -168,7 +168,9 @@ func (c *Controller) GarbageCollectRefs(ctx context.Context) error {
 		return err
 	}
 
-	for _, ref := range storedRefs {
+	storedRefsLen := len(storedRefs)
+	for i, ref := range storedRefs {
+		log.WithFields(log.Fields{"progress": i, "total": storedRefsLen}).Debug("ongoing 'refs' garbage collection")
 		if c.Store.HasRefExpired(ctx, ref.Key()) {
 			if err = deleteRef(ctx, c.Store, ref, "expired"); err != nil {
 				return err
@@ -284,7 +286,9 @@ func (c *Controller) GarbageCollectMetrics(ctx context.Context) error {
 		return err
 	}
 
+	storedMetricsLen := len(storedMetrics)
 	for k, m := range storedMetrics {
+		log.WithFields(log.Fields{"progress": k, "total": storedMetricsLen}).Debug("ongoing 'metrics' garbage collection")
 		if c.Store.HasMetricExpired(ctx, m.Key()) {
 			if err = deleteMetric(ctx, c.Store, m, "expired"); err != nil {
 				return err

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -26,6 +26,21 @@ type Local struct {
 	executedTasksCount uint64
 }
 
+// HasProjectExpired ..
+func (l *Local) HasProjectExpired(ctx context.Context, key schemas.ProjectKey) bool {
+	return false
+}
+
+// HasRefExpired ..
+func (l *Local) HasRefExpired(ctx context.Context, key schemas.RefKey) bool {
+	return false
+}
+
+// HasMetricExpired ..
+func (l *Local) HasMetricExpired(ctx context.Context, key schemas.MetricKey) bool {
+	return false
+}
+
 // SetProject ..
 func (l *Local) SetProject(_ context.Context, p schemas.Project) error {
 	l.projectsMutex.Lock()

--- a/pkg/store/redis.go
+++ b/pkg/store/redis.go
@@ -25,7 +25,28 @@ const (
 // Redis ..
 type Redis struct {
 	*redis.Client
+	StoreConfig *RedisStoreConfig
 }
+
+// RedisStoreConfig allows to fine tune the store behaviour
+type RedisStoreConfig struct {
+	TTLConfig *RedisTTLConfig
+}
+
+// RedisTTLConfig allows to set the TTL values for the various fields tracked
+type RedisTTLConfig struct {
+	Project time.Duration
+	Ref     time.Duration
+	Metric  time.Duration
+}
+
+func WithTTLConfig(opt *RedisTTLConfig) func(*RedisStoreConfig) {
+	return func(cfg *RedisStoreConfig) {
+		cfg.TTLConfig = opt
+	}
+}
+
+type RedisStoreOptions func(opts *RedisStoreConfig)
 
 // SetProject ..
 func (r *Redis) SetProject(ctx context.Context, p schemas.Project) error {
@@ -35,6 +56,13 @@ func (r *Redis) SetProject(ctx context.Context, p schemas.Project) error {
 	}
 
 	_, err = r.HSet(ctx, redisProjectsKey, string(p.Key()), marshalledProject).Result()
+	if err != nil {
+		return err
+	}
+
+	if r.StoreConfig.TTLConfig != nil {
+		_, err = r.Set(ctx, getTTLProjectKey(p.Key()), true, r.StoreConfig.TTLConfig.Project).Result()
+	}
 
 	return err
 }
@@ -183,6 +211,13 @@ func (r *Redis) SetRef(ctx context.Context, ref schemas.Ref) error {
 	}
 
 	_, err = r.HSet(ctx, redisRefsKey, string(ref.Key()), marshalledRef).Result()
+	if err != nil {
+		return err
+	}
+
+	if r.StoreConfig.TTLConfig != nil {
+		_, err = r.Set(ctx, getTTLRefKey(ref.Key()), true, r.StoreConfig.TTLConfig.Ref).Result()
+	}
 
 	return err
 }
@@ -257,6 +292,13 @@ func (r *Redis) SetMetric(ctx context.Context, m schemas.Metric) error {
 	}
 
 	_, err = r.HSet(ctx, redisMetricsKey, string(m.Key()), marshalledMetric).Result()
+	if err != nil {
+		return err
+	}
+
+	if r.StoreConfig.TTLConfig != nil {
+		_, err = r.Set(ctx, getTTLMetricKey(m.Key()), true, r.StoreConfig.TTLConfig.Metric).Result()
+	}
 
 	return err
 }
@@ -417,4 +459,46 @@ func (r *Redis) ExecutedTasksCount(ctx context.Context) (uint64, error) {
 	c, err := strconv.Atoi(countString)
 
 	return uint64(c), err
+}
+
+// HasProjectExpired ..
+func (r *Redis) HasProjectExpired(ctx context.Context, key schemas.ProjectKey) bool {
+	reply, err := r.Exists(ctx, getTTLProjectKey(key)).Result()
+	if err != nil {
+		return false
+	}
+
+	return reply > 0
+}
+
+func getTTLProjectKey(key schemas.ProjectKey) string {
+	return fmt.Sprintf("%s:%s", redisProjectsKey, key)
+}
+
+// HasRefExpired ..
+func (r *Redis) HasRefExpired(ctx context.Context, key schemas.RefKey) bool {
+	reply, err := r.Exists(ctx, getTTLRefKey(key)).Result()
+	if err != nil {
+		return false
+	}
+
+	return reply > 0
+}
+
+func getTTLRefKey(key schemas.RefKey) string {
+	return fmt.Sprintf("%s:%s", redisRefsKey, key)
+}
+
+// HasMetricExpired ..
+func (r *Redis) HasMetricExpired(ctx context.Context, key schemas.MetricKey) bool {
+	reply, err := r.Exists(ctx, getTTLMetricKey(key)).Result()
+	if err != nil {
+		return false
+	}
+
+	return reply > 0
+}
+
+func getTTLMetricKey(key schemas.MetricKey) string {
+	return fmt.Sprintf("%s:%s", redisMetricsKey, key)
 }

--- a/pkg/store/redis_test.go
+++ b/pkg/store/redis_test.go
@@ -23,7 +23,7 @@ func newTestRedisStore(t *testing.T) (mr *miniredis.Miniredis, r Store) {
 		mr.Close()
 	})
 
-	return mr, NewRedisStore(redis.NewClient(&redis.Options{Addr: mr.Addr()})).(*Redis)
+	return mr, NewRedisStore(redis.NewClient(&redis.Options{Addr: mr.Addr()}))
 }
 
 func TestRedisProjectFunctions(t *testing.T) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -64,7 +64,8 @@ func NewLocalStore() Store {
 // NewRedisStore ..
 func NewRedisStore(client *redis.Client, opts ...RedisStoreOptions) *Redis {
 	r := &Redis{
-		Client: client,
+		Client:      client,
+		StoreConfig: &RedisStoreConfig{},
 	}
 
 	for _, opt := range opts {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -37,8 +37,9 @@ func TestNew(t *testing.T) {
 	assert.IsType(t, &Local{}, localStore)
 
 	redisClient := redis.NewClient(&redis.Options{})
-	redisStore := New(testCtx, redisClient, config.Projects{})
-	assert.IsType(t, &Redis{}, redisStore)
+	redisStore := NewRedisStore(redisClient)
+	store := New(testCtx, redisStore, config.Projects{})
+	assert.IsType(t, &Redis{}, store)
 
 	localStore = New(testCtx, nil, config.Projects{
 		{


### PR DESCRIPTION
This adds a way to garbage collect the metrics based on a TTL. 

To make this work, we add a new key for each ref and metric with expiry; if this key doesn't exist anymore when doing garbage collection, we delete the field in the map.

TTL on HashMap field is supported in Redis 7.4, but it is not yet supported in the gp-redis library, so it is probably too early to be used