### PR TITLE
fix: Duplicate ref for mrs

### DIFF
--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -38,13 +38,13 @@ func (c *Controller) processPipelineEvent(ctx context.Context, e goGitlab.Pipeli
 	))
 }
 
-func (c *Controller) processJobEvent(ctx context.Context, e goGitlab.JobEvent) {
+func (c *Controller) processJobEvent(ctx context.Context, e goGitlab.JobEvent) error {
 	var (
 		refKind schemas.RefKind
 		refName = e.Ref
 	)
 
-	if iid, err := schemas.GetMergeRequestIIDFromRefName(refName); err != nil {
+	if iid, err := schemas.GetMergeRequestIIDFromRefName(refName); err == nil {
 		refKind = schemas.RefKindMergeRequest
 		refName = iid
 	} else if e.Tag {
@@ -59,7 +59,7 @@ func (c *Controller) processJobEvent(ctx context.Context, e goGitlab.JobEvent) {
 			WithError(err).
 			Error("reading project from GitLab")
 
-		return
+		return err
 	}
 
 	c.triggerRefMetricsPull(ctx, schemas.NewRef(
@@ -67,6 +67,8 @@ func (c *Controller) processJobEvent(ctx context.Context, e goGitlab.JobEvent) {
 		refKind,
 		refName,
 	))
+
+	return nil
 }
 
 func (c *Controller) processPushEvent(ctx context.Context, e goGitlab.PushEvent) {

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -44,7 +44,10 @@ func (c *Controller) processJobEvent(ctx context.Context, e goGitlab.JobEvent) {
 		refName = e.Ref
 	)
 
-	if e.Tag {
+	if iid, err := schemas.GetMergeRequestIIDFromRefName(refName); err != nil {
+		refKind = schemas.RefKindMergeRequest
+		refName = iid
+	} else if e.Tag {
 		refKind = schemas.RefKindTag
 	} else {
 		refKind = schemas.RefKindBranch

--- a/pkg/controller/webhooks_test.go
+++ b/pkg/controller/webhooks_test.go
@@ -1,6 +1,13 @@
 package controller
 
 import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/xanzy/go-gitlab"
+	"io"
+	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,4 +61,71 @@ func TestTriggerEnvironmentMetricsPull(t *testing.T) {
 	// TODO: Assert results somehow
 	c.triggerEnvironmentMetricsPull(ctx, env1)
 	c.triggerEnvironmentMetricsPull(ctx, env2)
+}
+
+func TestController_processJobEvent(t *testing.T) {
+	ctx, c, mux, srv := newTestController(config.Config{
+		Wildcards: config.Wildcards{
+			{
+				Search: "*",
+				Owner: config.WildcardOwner{
+					Name:             "foo",
+					Kind:             "group",
+					IncludeSubgroups: false,
+				},
+				Archived: false,
+				ProjectParameters: config.ProjectParameters{
+					Pull: config.ProjectPull{
+						Refs: config.ProjectPullRefs{
+							Branches: config.ProjectPullRefsBranches{
+								Enabled:        true,
+								Regexp:         "master",
+								MostRecent:     1,
+								MaxAgeSeconds:  0,
+								ExcludeDeleted: true,
+							},
+							Tags:          config.ProjectPullRefsTags{},
+							MergeRequests: config.ProjectPullRefsMergeRequests{},
+						},
+					},
+					OutputSparseStatusMetrics: false,
+				},
+			},
+		},
+	})
+	defer srv.Close()
+
+	mux.HandleFunc("/api/v4/projects/380",
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"id":380,"path_with_namespace":"foo/bar","jobs_enabled":true}`)
+		})
+
+	val, err := readJobEvent(t, "../../testdata/webhook/job_events.json")
+	require.NoError(t, err)
+
+	err = c.processJobEvent(ctx, *val)
+	assert.NoError(t, err)
+
+	// Validate that the pull project task was queued
+	n, err := c.Store.CurrentlyQueuedTasksCount(ctx)
+	assert.Equal(t, uint64(1), n)
+}
+
+func readJobEvent(t *testing.T, filePath string) (*gitlab.JobEvent, error) {
+	t.Helper()
+	jsonFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := io.ReadAll(jsonFile)
+
+	var jobEnvent gitlab.JobEvent
+	err = json.Unmarshal(byteValue, &jobEnvent)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jobEnvent, nil
 }

--- a/pkg/schemas/ref.go
+++ b/pkg/schemas/ref.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	mergeRequestRegexp string = `^((\d+)|refs/merge-requests/(\d+)/(?:head|merge))$`
+	mergeRequestRegexp string = `^((\d+)|refs/merge-requests/(\d+)/(?:head|merge|train))$`
 
 	// RefKindBranch refers to a branch.
 	RefKindBranch RefKind = "branch"

--- a/testdata/webhook/job_events.json
+++ b/testdata/webhook/job_events.json
@@ -1,0 +1,82 @@
+{
+  "object_kind": "build",
+  "ref": "master",
+  "tag": false,
+  "before_sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
+  "sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
+  "build_id": 1977,
+  "build_name": "test",
+  "build_stage": "test",
+  "build_status": "created",
+  "build_created_at": "2021-02-23T02:41:37.886Z",
+  "build_started_at": null,
+  "build_finished_at": null,
+  "build_duration": null,
+  "build_queued_duration": 1095.588715,
+  "build_allow_failure": false,
+  "build_failure_reason": "script_failure",
+  "retries_count": 2,
+  "pipeline_id": 2366,
+  "project_id": 380,
+  "project_name": "gitlab-org/gitlab-test",
+  "user": {
+    "id": 3,
+    "name": "User",
+    "email": "user@gitlab.com",
+    "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+  },
+  "commit": {
+    "id": 2366,
+    "name": "Build pipeline",
+    "sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
+    "message": "test\n",
+    "author_name": "User",
+    "author_email": "user@gitlab.com",
+    "status": "created",
+    "duration": null,
+    "started_at": null,
+    "finished_at": null
+  },
+  "repository": {
+    "name": "gitlab_test",
+    "description": "Atque in sunt eos similique dolores voluptatem.",
+    "homepage": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
+    "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
+    "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
+    "visibility_level": 20
+  },
+  "project":{
+    "id": 380,
+    "name": "Gitlab Test",
+    "description": "Atque in sunt eos similique dolores voluptatem.",
+    "web_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
+    "avatar_url": null,
+    "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
+    "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
+    "namespace": "Gitlab Org",
+    "visibility_level": 20,
+    "path_with_namespace": "gitlab-org/gitlab-test",
+    "default_branch": "master"
+  },
+  "runner": {
+    "active": true,
+    "runner_type": "project_type",
+    "is_shared": false,
+    "id": 380987,
+    "description": "shared-runners-manager-6.gitlab.com",
+    "tags": [
+      "linux",
+      "docker"
+    ]
+  },
+  "environment": null,
+  "source_pipeline":{
+    "project":{
+      "id": 41,
+      "web_url": "https://gitlab.example.com/gitlab-org/upstream-project",
+      "path_with_namespace": "gitlab-org/upstream-project"
+    },
+    "pipeline_id": 30,
+    "job_id": 3401
+  }
+}


### PR DESCRIPTION
The webhook handler `processJobEvent` does not consider the case where the ref is a merge request pipeline or merge train.

So multiple refs are being created, one by the `processPipelineEvent` and the other by `processJobEvent

for instance, for a same MR we can have all three refs below:
```
380
/refs/merge-requests/380/head
/refs/merge-requests/380/train
```
